### PR TITLE
Add a toggle key to allow switching the UI overlay

### DIFF
--- a/src/main/java/uk/co/wehavecookies56/kk/client/core/handler/InputHandler.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/client/core/handler/InputHandler.java
@@ -28,6 +28,7 @@ import uk.co.wehavecookies56.kk.common.capability.DriveStateCapability.IDriveSta
 import uk.co.wehavecookies56.kk.common.capability.ModCapabilities;
 import uk.co.wehavecookies56.kk.common.capability.PlayerStatsCapability;
 import uk.co.wehavecookies56.kk.common.capability.SummonKeybladeCapability;
+import uk.co.wehavecookies56.kk.common.core.handler.ConfigHandler;
 import uk.co.wehavecookies56.kk.common.driveform.ModDriveForms;
 import uk.co.wehavecookies56.kk.common.entity.LockOn;
 import uk.co.wehavecookies56.kk.common.item.base.ItemDriveForm;
@@ -333,21 +334,33 @@ public class InputHandler {
 				PacketDispatcher.sendToServer(new OpenMenu());
 				break;
 				
+			case SHOW_GUI:
+				ConfigHandler.toggleShowGUI();
+				break;
+				
 			case SCROLL_UP:
+				if (!ConfigHandler.displayGUI())
+					break;
 				commandUp();
 				world.playSound(player, player.getPosition(), ModSounds.move, SoundCategory.MASTER, 1.0f, 1.0f);
 				break;
 
 			case SCROLL_DOWN:
+				if (!ConfigHandler.displayGUI())
+					break;
 				commandDown();
 				world.playSound(player, player.getPosition(), ModSounds.move, SoundCategory.MASTER, 1.0f, 1.0f);
 				break;
 
 			case ENTER:
+				if (!ConfigHandler.displayGUI())
+					break;
 				commandEnter();
 				break;
 
 			case BACK:
+				if (!ConfigHandler.displayGUI())
+					break;
 				commandBack();
 				break;
 			case SUMMON_KEYBLADE:
@@ -507,7 +520,7 @@ public class InputHandler {
 
 	public static enum Keybinds {
 
-        OPENMENU ("key.kingdomkeys.openmenu", Keyboard.KEY_M), SCROLL_UP ("key.kingdomkeys.scrollup", Keyboard.KEY_UP), SCROLL_DOWN ("key.kingdomkeys.scrolldown", Keyboard.KEY_DOWN), ENTER ("key.kingdomkeys.enter", Keyboard.KEY_RIGHT), BACK ("key.kingdomkeys.back", Keyboard.KEY_LEFT), SCROLL_ACTIVATOR ("key.kingdomkeys.scrollactivator", Keyboard.KEY_LMENU), SUMMON_KEYBLADE ("key.kingdomkeys.summonkeyblade", Keyboard.KEY_G), LOCK_ON ("key.kingdomkeys.lockon", Keyboard.KEY_Z);
+        OPENMENU ("key.kingdomkeys.openmenu", Keyboard.KEY_M), SCROLL_UP ("key.kingdomkeys.scrollup", Keyboard.KEY_UP), SCROLL_DOWN ("key.kingdomkeys.scrolldown", Keyboard.KEY_DOWN), ENTER ("key.kingdomkeys.enter", Keyboard.KEY_RIGHT), BACK ("key.kingdomkeys.back", Keyboard.KEY_LEFT), SCROLL_ACTIVATOR ("key.kingdomkeys.scrollactivator", Keyboard.KEY_LMENU), SUMMON_KEYBLADE ("key.kingdomkeys.summonkeyblade", Keyboard.KEY_G), LOCK_ON ("key.kingdomkeys.lockon", Keyboard.KEY_Z), SHOW_GUI ("key.kingdomkeys.showgui", Keyboard.KEY_O);
 
         private final KeyBinding keybinding;
 

--- a/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiCommandMenu.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiCommandMenu.java
@@ -18,6 +18,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import uk.co.wehavecookies56.kk.common.capability.DriveStateCapability.IDriveState;
 import uk.co.wehavecookies56.kk.common.capability.ModCapabilities;
 import uk.co.wehavecookies56.kk.common.capability.PlayerStatsCapability;
+import uk.co.wehavecookies56.kk.common.core.handler.ConfigHandler;
 import uk.co.wehavecookies56.kk.common.core.handler.event.EntityEvents;
 import uk.co.wehavecookies56.kk.common.item.base.ItemDriveForm;
 import uk.co.wehavecookies56.kk.common.item.base.ItemKKPotion;
@@ -67,7 +68,7 @@ public class GuiCommandMenu extends GuiScreen {
 	public void onRenderOverlayPost (RenderGameOverlayEvent event) {
 		if(mc.player.getCapability(ModCapabilities.PLAYER_STATS, null).getHudMode())
 		{
-			if (event.getType() == RenderGameOverlayEvent.ElementType.TEXT && !mc.ingameGUI.getChatGUI().getChatOpen()) {
+			if (event.getType() == RenderGameOverlayEvent.ElementType.TEXT && !mc.ingameGUI.getChatGUI().getChatOpen() && ConfigHandler.displayGUI()) {
 				GL11.glPushMatrix();
 				{
 					drawCommandMenu(event.getResolution().getScaledWidth(), event.getResolution().getScaledHeight());

--- a/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiDrive.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiDrive.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import uk.co.wehavecookies56.kk.common.capability.ModCapabilities;
 import uk.co.wehavecookies56.kk.common.capability.PlayerStatsCapability;
+import uk.co.wehavecookies56.kk.common.core.handler.ConfigHandler;
 import uk.co.wehavecookies56.kk.common.lib.Constants;
 import uk.co.wehavecookies56.kk.common.lib.Reference;
 import uk.co.wehavecookies56.kk.common.util.Utils;
@@ -63,6 +64,8 @@ public class GuiDrive extends GuiScreen {
 
 	@SubscribeEvent
 	public void onRenderOverlayPost (RenderGameOverlayEvent event) {
+		if (!ConfigHandler.displayGUI())
+			return;
 		if(!mc.player.getCapability(ModCapabilities.PLAYER_STATS, null).getHudMode()) return;
 
 		PlayerStatsCapability.IPlayerStats STATS = mc.player.getCapability(ModCapabilities.PLAYER_STATS, null);

--- a/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiHP.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiHP.java
@@ -119,6 +119,8 @@ public class GuiHP extends GuiScreen {
 
 	@SubscribeEvent
 	public void onRenderOverlayPost (RenderGameOverlayEvent event) {
+		if (!ConfigHandler.displayGUI())
+			return;
 		if(!Minecraft.getMinecraft().player.getCapability(ModCapabilities.PLAYER_STATS, null).getHudMode()) return;
 		if (event.getType().equals(ElementType.HEALTH) && event.isCancelable()) if (!ConfigHandler.EnableHeartsOnHUD) event.setCanceled(true);
 		if (event.getType() == RenderGameOverlayEvent.ElementType.TEXT) {

--- a/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiMP.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiMP.java
@@ -10,6 +10,7 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import uk.co.wehavecookies56.kk.common.capability.ModCapabilities;
 import uk.co.wehavecookies56.kk.common.capability.PlayerStatsCapability;
+import uk.co.wehavecookies56.kk.common.core.handler.ConfigHandler;
 import uk.co.wehavecookies56.kk.common.lib.Constants;
 import uk.co.wehavecookies56.kk.common.lib.Reference;
 
@@ -22,6 +23,8 @@ public class GuiMP extends GuiScreen {
 
 	@SubscribeEvent
 	public void onRenderOverlayPost (RenderGameOverlayEvent event) {
+		if (!ConfigHandler.displayGUI())
+			return;
 		if(!Minecraft.getMinecraft().player.getCapability(ModCapabilities.PLAYER_STATS, null).getHudMode()) return;
 		if (event.getType() == RenderGameOverlayEvent.ElementType.TEXT) {
 

--- a/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiPlayerPortrait.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/client/gui/GuiPlayerPortrait.java
@@ -10,6 +10,7 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import uk.co.wehavecookies56.kk.common.capability.DriveStateCapability;
 import uk.co.wehavecookies56.kk.common.capability.ModCapabilities;
+import uk.co.wehavecookies56.kk.common.core.handler.ConfigHandler;
 import uk.co.wehavecookies56.kk.common.lib.Constants;
 import uk.co.wehavecookies56.kk.common.lib.Reference;
 import uk.co.wehavecookies56.kk.common.lib.Strings;
@@ -20,6 +21,8 @@ public class GuiPlayerPortrait extends GuiScreen {
 
 	@SubscribeEvent
 	public void onRenderOverlayPost (RenderGameOverlayEvent event) {
+		if (!ConfigHandler.displayGUI())
+			return;
 		Minecraft mc = Minecraft.getMinecraft();
 		if(!mc.player.getCapability(ModCapabilities.PLAYER_STATS, null).getHudMode()) return;
 		int screenWidth = event.getResolution().getScaledWidth();

--- a/src/main/java/uk/co/wehavecookies56/kk/common/core/handler/ConfigHandler.java
+++ b/src/main/java/uk/co/wehavecookies56/kk/common/core/handler/ConfigHandler.java
@@ -2,11 +2,15 @@ package uk.co.wehavecookies56.kk.common.core.handler;
 
 import java.io.File;
 
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import uk.co.wehavecookies56.kk.common.item.base.ItemKeyblade;
 import uk.co.wehavecookies56.kk.common.lib.Reference;
 
 public class ConfigHandler {
@@ -34,14 +38,15 @@ public class ConfigHandler {
 			redNocturneRatio=10,
 			blueRhapsodyRatio=10,
 			yellowOperaRatio=10,
-			greenRequiemRatio=10
+			greenRequiemRatio=10,
+			AlwaysShowGUI = 2
 			;
 	
 	public static double damageMultiplier = 1;
 	
 	public static boolean chat = true;
 	
-	public static Property interfaceColourProperty, EnableHeartsOnHUDProperty, EnableCustomMusicProperty;
+	public static Property interfaceColourProperty, EnableHeartsOnHUDProperty, EnableCustomMusicProperty, AlwaysShowGUIProperty;
 
 	public static void init(File file) {
 		config = new Configuration(file);
@@ -84,6 +89,10 @@ public class ConfigHandler {
 
 		interfaceColourProperty = configProperty("Interface colour", "Set the colour of the interface with RGB values", interfaceColour, INTERFACE);
 		interfaceColour = interfaceColourProperty.getIntList();
+
+		AlwaysShowGUIProperty = config.get(INTERFACE, "Always show GUI", AlwaysShowGUI);
+		AlwaysShowGUIProperty.setComment("Always show the GUI overlay mode (2 = always on, 1 = on with keyblade, 0 = off)");
+		AlwaysShowGUI = AlwaysShowGUIProperty.getInt();
 
 		//SOUND
 		EnableCustomMusicProperty = configBooleanProperty("Enable custom music", "Toggles the custom music that plays, requires the music resource pack", EnableCustomMusic, SOUND);
@@ -142,5 +151,21 @@ public class ConfigHandler {
 	@SubscribeEvent
 	public void OnConfigChanged (ConfigChangedEvent.OnConfigChangedEvent event) {
 		if (event.getModID().equals(Reference.MODID)) load();
+	}
+	
+	public static void toggleShowGUI () {
+		AlwaysShowGUI += 1;
+		if (AlwaysShowGUI > 2)
+			AlwaysShowGUI = 0;
+		AlwaysShowGUIProperty.set(AlwaysShowGUI);
+		config.save();
+	}
+	
+	@SideOnly(Side.CLIENT)
+	public static boolean displayGUI () {
+		if (AlwaysShowGUI == 0)
+			return false;
+		Minecraft mc = Minecraft.getMinecraft();
+		return ((AlwaysShowGUI == 2) || ((mc.player.getHeldItemMainhand() != null) && (mc.player.getHeldItemMainhand().getItem() instanceof ItemKeyblade)));
 	}
 }

--- a/src/main/resources/assets/kk/lang/en_US.lang
+++ b/src/main/resources/assets/kk/lang/en_US.lang
@@ -779,6 +779,7 @@ key.kingdomkeys.scrolldown=Command Menu Scroll Down
 key.kingdomkeys.scrollup=Command Menu Scroll Up
 key.kingdomkeys.openmenu=Open Menu
 key.kingdomkeys.summonkeyblade=Summon Keyblade
+key.kingdomkeys.showgui=Toggle Always Show GUI mode (on/off/on with keyblade)
 
 ############################
 #Spells and forms


### PR DESCRIPTION
On a multimod server not all players might want to play with this mod, and even if, they might not always want to have the UI overlay visible.

This PR adds a keybind that allows the player to toggle the UI between always on, always off and on with a keyblade in your hand.